### PR TITLE
Use logback instead of slf4j-simple. Use file for debug messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,15 +18,12 @@ dependencies {
     compile 'com.opencsv:opencsv:3.9'
     compile 'org.knowm:yank:3.3.0'
     compile 'org.postgresql:postgresql:42.0.0'
-    compile 'org.slf4j:slf4j-simple:1.7.24'
     compile 'ch.qos.logback:logback-classic:1.2.3'
-
 
     // Use TestNG framework, also requires calling test.useTestNG() below
     testCompile 'org.testng:testng:6.10'
 }
 
-//noinspection GroovyUnusedAssignment
 mainClassName = 'com.gradle.exportapi.Application'
 
 run {
@@ -35,5 +32,3 @@ run {
 }
 
 test.useTestNG()
-
-

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,10 +7,20 @@
         </layout>
     </appender>
 
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file> export.log </file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
     <logger name="com.base22" level="TRACE"/>
 
-
     <root level="debug">
+        <appender-ref ref="FILE" />
+    </root>
+    <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
With two slf4j implementations on the classpath, logback wasn't actually being loaded. This gets rid of slf4j-simple.

Which allows us to specify a separate file appender in logback.xml for lower priority/debug messages and keep the console that much cleaner. 