### PR TITLE
Make task and test DAOs resilient to NPEs thrown when calculating duration

### DIFF
--- a/src/main/java/com/gradle/exportapi/dao/TasksDAO.java
+++ b/src/main/java/com/gradle/exportapi/dao/TasksDAO.java
@@ -11,11 +11,19 @@ public class TasksDAO {
     static final Logger log = LoggerFactory.getLogger(TasksDAO.class);
 
     public static long insertTask(Task task) {
+        // If the task executor crashed, checking its duration may result in an NPE
+        long duration = 0;
+        try {
+            duration = task.getTimer().durationInMillis();
+        } catch (Exception e) {
+            log.warn("Failed to get duration of task " + task.getPath() + " for build " + task.getBuildId(), e);
+        }
+
         Object[] params = new Object[] {
                 task.getTaskId(),
                 task.getBuildId(),
                 task.getPath(),
-                task.getTimer().durationInMillis(),
+                duration,
                 task.getOutcome()};
 
         String SQL = insert("tasks (task_id, build_id, path, duration_millis, outcome)", params);

--- a/src/main/java/com/gradle/exportapi/dao/TestsDAO.java
+++ b/src/main/java/com/gradle/exportapi/dao/TestsDAO.java
@@ -12,6 +12,24 @@ public class TestsDAO {
     static final Logger log = LoggerFactory.getLogger(TestsDAO.class);
 
     public static long insertTest(Test test) {
+
+        // If the task executor crashed, checking its duration may result in an NPE
+        long duration = 0;
+        try {
+            duration = test.getTimer().durationInMillis();
+        } catch (Exception e) {
+            log.warn("Failed to get duration of test " + test.getName() + " in build " + test.getBuildId() +
+                     ", setting its duration to " + duration);
+            log.debug("test " + test.getName() + " in build " + test.getBuildId(), e);
+        }
+
+        // If the task executor crashed, its status may be null
+        if(test.getStatus() == null) {
+            log.warn("Test " + test.getName() + " for build " + test.getBuildId() + " has no value for status, " +
+                     "recording its status as 'error'");
+            test.setStatus("error");
+        }
+
         Object[] params = new Object[] {
                 test.getBuildId(),
                 test.getTaskId(),
@@ -19,7 +37,7 @@ public class TestsDAO {
                 test.getName(),
                 test.getClassName(),
                 test.getStatus(),
-                test.getTimer().durationInMillis(),
+                duration,
         };
 
         String SQL = insert("tests (build_id, task_id, test_id, name, class_name, status, duration_millis)", params);


### PR DESCRIPTION
Sometimes gradle test execution processes crash. Whether because the test called System.exit() or loaded some native code in-proc which segfaulted, the final record in the build scan can end up with no status and no end time. 

This PR logs a warning when that happens, sets the duration to 0, sets the status to "error" and continues on. 